### PR TITLE
Fix static asset detection in service worker

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -70,6 +70,7 @@ self.addEventListener('activate', event => {
 // Fetch event - serve from cache, fallback to network
 self.addEventListener('fetch', event => {
     const { request } = event;
+    const requestURL = new URL(request.url);
     
     // Skip cross-origin requests
     if (!request.url.startsWith(self.location.origin) && 
@@ -101,7 +102,9 @@ self.addEventListener('fetch', event => {
     }
     
     // Cache-first strategy for static assets
-    if (STATIC_ASSETS.some(asset => request.url.includes(asset))) {
+    // Use the request pathname for exact matching instead of substring search
+    // to avoid '/' matching every request
+    if (STATIC_ASSETS.includes(requestURL.pathname)) {
         event.respondWith(
             caches.match(request)
                 .then(cachedResponse => {


### PR DESCRIPTION
## Summary
- Avoid matching every URL as a static asset in service worker
- Use pathname-based comparison for accurate cache-first logic

## Testing
- `node --check sw.js`
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ce1402864832785b9d3d9f8ecf0f9